### PR TITLE
set tls default min version to avoid error

### DIFF
--- a/src/commands/registration/auth.js
+++ b/src/commands/registration/auth.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const tls = require('tls');
+const tls = require('tls').DEFAULT_MIN_VERSION = 'TLSv1';
 
 module.exports = {
   directive: 'AUTH',

--- a/src/connector/active.js
+++ b/src/connector/active.js
@@ -1,5 +1,5 @@
 const {Socket} = require('net');
-const tls = require('tls');
+const tls = require('tls').DEFAULT_MIN_VERSION = 'TLSv1';
 const Promise = require('bluebird');
 const Connector = require('./base');
 

--- a/src/connector/passive.js
+++ b/src/connector/passive.js
@@ -1,5 +1,5 @@
 const net = require('net');
-const tls = require('tls');
+const tls = require('tls').DEFAULT_MIN_VERSION = 'TLSv1';
 const ip = require('ip');
 const Promise = require('bluebird');
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const Promise = require('bluebird');
 const nodeUrl = require('url');
 const buyan = require('bunyan');
 const net = require('net');
-const tls = require('tls');
+const tls = require('tls').DEFAULT_MIN_VERSION = 'TLSv1';
 const EventEmitter = require('events');
 
 const Connection = require('./connection');


### PR DESCRIPTION
This PR is going to solve the open ssl error **ERR_SSL_UNSUPPORTED_PROTOCOL**, because TlS protocol and cipher version on client and user are not able to agree. Server should support oldest version of TLS. 

